### PR TITLE
Apply text color to system information text

### DIFF
--- a/hassio/src/system/hassio-system.js
+++ b/hassio/src/system/hassio-system.js
@@ -12,6 +12,7 @@ class HassioSystem extends PolymerElement {
       <style include="iron-flex ha-style">
         .content {
           margin: 4px;
+          color: var(--primary-text-color);
         }
         .title {
           margin-top: 24px;


### PR DESCRIPTION
Apply primary-text-color to content so the system information text can be themed.  Currently text remains black, which is unreadable on dark themes.  Should resolve the issue below.

[](https://github.com/home-assistant/hassio/issues/918)
